### PR TITLE
add `score` field to audits collection 

### DIFF
--- a/backend/pb_migrations/1743055714_updated_audits.js
+++ b/backend/pb_migrations/1743055714_updated_audits.js
@@ -1,0 +1,27 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_89547554")
+
+  // add field
+  collection.fields.addAt(6, new Field({
+    "hidden": false,
+    "id": "number848901969",
+    "max": null,
+    "min": null,
+    "name": "score",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_89547554")
+
+  // remove field
+  collection.fields.removeById("number848901969")
+
+  return app.save(collection)
+})

--- a/backend/pb_migrations/1743055753_updated_audits.js
+++ b/backend/pb_migrations/1743055753_updated_audits.js
@@ -1,0 +1,38 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_89547554")
+
+  // update field
+  collection.fields.addAt(6, new Field({
+    "hidden": false,
+    "id": "number848901969",
+    "max": 100,
+    "min": null,
+    "name": "score",
+    "onlyInt": false,
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "number"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_89547554")
+
+  // update field
+  collection.fields.addAt(6, new Field({
+    "hidden": false,
+    "id": "number848901969",
+    "max": null,
+    "min": null,
+    "name": "score",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  return app.save(collection)
+})

--- a/backend/pb_migrations/1743055782_updated_audits.js
+++ b/backend/pb_migrations/1743055782_updated_audits.js
@@ -1,0 +1,38 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_89547554")
+
+  // update field
+  collection.fields.addAt(6, new Field({
+    "hidden": false,
+    "id": "number848901969",
+    "max": 100,
+    "min": null,
+    "name": "score",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_89547554")
+
+  // update field
+  collection.fields.addAt(6, new Field({
+    "hidden": false,
+    "id": "number848901969",
+    "max": 100,
+    "min": null,
+    "name": "score",
+    "onlyInt": false,
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "number"
+  }))
+
+  return app.save(collection)
+})


### PR DESCRIPTION
Closes #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Audit records now include a new numeric score field (max value of 100) to capture additional metrics, enhancing the clarity and detail of audit reporting.
  - This update improves the precision of audit data, ensuring more reliable and informative histories for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->