### PR TITLE
refactor(useAuditStatus): Improve start date calculation for audit frequency

### DIFF
--- a/crm/src/api/useAuditStatus.ts
+++ b/crm/src/api/useAuditStatus.ts
@@ -31,11 +31,21 @@ const fetchAudits = async (accountId: string): Promise<Audit[]> => {
   }));
 };
 
-function getLastCompletedAuditDate(audits: Audit[]): Date | null {
+// This function now gets the last completed audit date, or falls back to the most recent audit of any status
+function getLastAuditDate(audits: Audit[]): Date | null {
+  // First try to get the most recent completed audit
   const completed = audits.filter((a) => a.status === "completed");
-  if (completed.length === 0) return null;
+  if (completed.length > 0) {
+    return new Date(
+      Math.max(...completed.map((audit) => new Date(audit.date).getTime())),
+    );
+  }
+  
+  // If no completed audits, fall back to the most recent audit of any status
+  if (audits.length === 0) return null;
+  
   return new Date(
-    Math.max(...completed.map((audit) => new Date(audit.date).getTime())),
+    Math.max(...audits.map((audit) => new Date(audit.date).getTime())),
   );
 }
 
@@ -118,7 +128,8 @@ export const useAuditStatus = (
 
       if (audits.length === 0) return [];
 
-      const startDate = getLastCompletedAuditDate(audits) || new Date();
+      // Use the new function instead of getLastCompletedAuditDate
+      const startDate = getLastAuditDate(audits) || new Date();
       const expected = generateExpectedDates(
         startDate,
         account.frequency,


### PR DESCRIPTION
- Modified getLastCompletedAuditDate to getLastAuditDate which falls back to the most recent audit of any status when no completed audits exist
- Ensures audit schedule follows the actual audit history rather than defaulting to current date
- Improves accuracy of badge status indicators for accounts with no completed audits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the logic for determining the most recent audit date so that the system now reliably displays a relevant audit date even when a completed audit is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->